### PR TITLE
ci: hotfix bump actions/upload-pages-artifact@v3

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
       -
         uses: actions/checkout@v2
       -
-        run: sudo apt-get -y install cppcheck
+        run: sudo apt-get -y install cppcheck --no-install-recommends
       - 
         run: cppcheck gly_type_render.h
 

--- a/.github/workflows/DOCS.yml
+++ b/.github/workflows/DOCS.yml
@@ -33,7 +33,7 @@ jobs:
       - 
         uses: actions/configure-pages@v3
       -
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
           path: 'html'
       - 

--- a/.github/workflows/DOCS.yml
+++ b/.github/workflows/DOCS.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - 
         uses: actions/checkout@master
+      -
+        run: sudo apt-get -y install imagemagick --no-install-recommends
       - 
         run: |
           make doxfilter font.png

--- a/.github/workflows/DOCS.yml
+++ b/.github/workflows/DOCS.yml
@@ -33,11 +33,11 @@ jobs:
           sudo rm html/index.html
           sudo mv html/gly__type__render_8h.html html/index.html
       - 
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
       -
         uses: actions/upload-pages-artifact@v3
         with:
           path: 'html'
       - 
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/DOCS.yml
+++ b/.github/workflows/DOCS.yml
@@ -33,7 +33,7 @@ jobs:
       - 
         uses: actions/configure-pages@v3
       -
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v4
         with:
           path: 'html'
       - 


### PR DESCRIPTION
 * https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/